### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,7 +73,7 @@ points to the right binary.
    python -m venv venv
    source venv/bin/activate
    # Install the package into the virtual environment
-   pip install --use-feature=2020-resolver -r acmetk/requirements.txt
+   pip install -r acmetk/requirements.txt
    pip install acmetk/.
    # Generate an account key for the internal ACME client
    python -m acmetk generate-account-key -k rsa /etc/acmetk/broker_client_account.key


### PR DESCRIPTION
Pip complains:
```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```