### PR TITLE
eab - hmac size of 256 bits as required by rfc7518

### DIFF
--- a/acmetk/server/external_account_binding.py
+++ b/acmetk/server/external_account_binding.py
@@ -38,7 +38,7 @@ class ExternalAccountBinding:
         """The key identifier provided by the external binding mechanism."""
         self.url: str = url
         """The *newAccount* URL which is the same as in the encapsulating JWS."""
-        self.hmac_key: str = secrets.token_urlsafe(16)
+        self.hmac_key: str = secrets.token_urlsafe(32)
         """The key that is used to symmetrically sign the JWS."""
         self.when: datetime.datetime = datetime.datetime.now()
         """The time when the EAB request was created."""


### PR DESCRIPTION
c.f.
https://github.com/go-acme/lego/issues/2142#issuecomment-2005688844