### PR TITLE
fix(alembic): name orders.account_kid FK explicitly

### DIFF
--- a/alembic/versions/5b6b2b8a6b07_init.py
+++ b/alembic/versions/5b6b2b8a6b07_init.py
@@ -90,6 +90,7 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["account_kid"],
             ["accounts.kid"],
+            name="orders_account_kid_fkey",
         ),
         sa.PrimaryKeyConstraint("order_id"),
     )


### PR DESCRIPTION
## Problem

`alembic upgrade head` from an empty database fails on the `keychange` migration (`da620267c2f6`):

```
psycopg2.errors.UndefinedObject: constraint "orders_account_kid_fkey" of relation "orders" does not exist
```

`keychange` does:

```python
op.drop_constraint("orders_account_kid_fkey", "orders", type_="foreignkey")
```

…but the init migration (`5b6b2b8a6b07`) creates the orders → accounts FK anonymously:

```python
sa.ForeignKeyConstraint(
    ["account_kid"],
    ["accounts.kid"],
),
```

Postgres' default name for an anonymous FK in this position works out to `orders_account_kid_fkey` on most setups, but it's not guaranteed by SQLAlchemy/Alembic. On the systems where I ran into this it was named differently (or not present at all under some metadata-naming-convention setups), so the hardcoded drop in `keychange` failed.

## Fix

Pass `name="orders_account_kid_fkey"` to the ForeignKeyConstraint so the name is deterministic and matches what `keychange` expects.

## Test

`docker compose up` against an empty Postgres + `python -m acmetk run --alembic-upgrade true` now runs the full chain (init → keychange → using_jsonb → profiles → ari → profile_length) cleanly:

```
alembic.runtime.migration - INFO - Running upgrade  -> 5b6b2b8a6b07, init
alembic.runtime.migration - INFO - Running upgrade 5b6b2b8a6b07 -> da620267c2f6, keychange
alembic.runtime.migration - INFO - Running upgrade da620267c2f6 -> 24004ca7a5ea, using JSONB
alembic.runtime.migration - INFO - Running upgrade 24004ca7a5ea -> 9a65b93bfa0a, Order has profiles field
alembic.runtime.migration - INFO - Running upgrade 9a65b93bfa0a -> 4245b2ccf302, ARI
alembic.runtime.migration - INFO - Running upgrade 4245b2ccf302 -> 3b9114fe9d3a, profile length
```

No-op for databases already past the keychange revision.