### PR TITLE
fix(lexicon): drop bogus asserts in cleanup_challenge

### DIFF
--- a/acmetk/plugins/lexicon_solver.py
+++ b/acmetk/plugins/lexicon_solver.py
@@ -214,10 +214,11 @@ class LexiconChallengeSolver(DNS01ChallengeHelper, ChallengeSolver):
         cfg = await self._config_for(name)
 
         try:
-            #            provider.domain = await self._find_domain_id(provider, name)
+            # Lexicon Client.__enter__ authenticates the provider; delete_record
+            # works without us poking provider.zone/.domain ourselves (and on some
+            # lexicon versions those attributes do not exist as fields on Provider,
+            # which broke cleanup on every successful issuance).
             with lexicon.client.Client(cfg) as ops:
-                assert ops.provider.zone is not None, ops.provider.zone
-                assert ops.provider.domain
                 await self.delete_txt_record(ops, name, text)
         except Exception as e:
-            logger.exception(e)
+            logger.exception("cleanup_challenge failed for %s: %s", name, e)


### PR DESCRIPTION
## Problem

After every successful issuance with the lexicon solver, the cleanup path crashes:

```
acmetk.plugins.lexicon_solver - ERROR - 'Provider' object has no attribute 'zone'
Traceback (most recent call last):
  File "/app/acmetk/plugins/lexicon_solver.py", line 219, in cleanup_challenge
    assert ops.provider.zone is not None, ops.provider.zone
AttributeError: 'Provider' object has no attribute 'zone'
```

The exception fires **before** `delete_txt_record` is called, so the `_acme-challenge.*` TXT record stays in the upstream DNS provider forever. New issuances for the same FQDN then 400 on the duplicate add.

## Root cause

`cleanup_challenge` ends with:

```python
try:
    with lexicon.client.Client(cfg) as ops:
        assert ops.provider.zone is not None, ops.provider.zone
        assert ops.provider.domain
        await self.delete_txt_record(ops, name, text)
except Exception as e:
    logger.exception(e)
```

The two asserts dereference internal lexicon Provider attributes that aren't exposed as fields on every provider (this PR was developed against the Cloudflare provider, where neither is a top-level attribute). The asserts contribute nothing to the cleanup itself — `delete_txt_record` works without them — and they introduce a hard dependency on internal lexicon shape.

## Fix

Remove the asserts. Slightly tighten the exception log to include the record name so it's actionable when something else does go wrong.

## Test

Issued a cert via `acme.sh` against an acmetk broker with the lexicon Cloudflare solver. No exception in the broker log, `_acme-challenge.*.example.com` TXT record is correctly removed after issuance.