### PR TITLE
server - add Retry-After header for order & authz

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -99,9 +99,10 @@ jobs:
         pdm run coverage run --data-file=profile.coverage -m pytest "tests/profile_test.py"
         pdm run coverage run --data-file=ari.coverage -m pytest "tests/ari_test.py"
         pdm run coverage run --data-file=config.coverage -m pytest "tests/config_test.py"
+        pdm run coverage run --data-file=retryafter.coverage -m pytest "tests/retryafter_test.py"
         pdm install -G metrics
         pdm run coverage run --data-file=metrics.coverage -m pytest "tests/metrics_test.py"
-        pdm run coverage combine --data-file=.coverage ca.coverage eab-ca.coverage broker-ca.coverage mgmt.coverage chalval_tlsalpn01.coverage chalval_http01.coverage profile.coverage config.coverage ari.coverage metrics.coverage
+        pdm run coverage combine --data-file=.coverage ca.coverage eab-ca.coverage broker-ca.coverage mgmt.coverage chalval_tlsalpn01.coverage chalval_http01.coverage profile.coverage config.coverage ari.coverage retryafter.coverage metrics.coverage
         pdm run coverage xml --data-file=.coverage -o coverage.xml
 
     - name: Upload coverage to Codecov

--- a/acmetk/client/client.py
+++ b/acmetk/client/client.py
@@ -45,11 +45,11 @@ ChallengeSolverRegistry = PluginRegistry.get_registry(ChallengeSolver)
 STATUS_EXPIRED = acme.messages.Status("expired")
 
 
-def is_valid(obj):
+def is_valid(obj: acme.messages.Authorization | messages.Order):
     return obj.status == acme.messages.STATUS_VALID
 
 
-def is_invalid(obj):
+def is_invalid(obj: acme.messages.Authorization | messages.Order):
     return obj.status in [acme.messages.STATUS_INVALID, STATUS_EXPIRED]
 
 
@@ -375,6 +375,7 @@ class AcmeClient:
             except acme.messages.Error as e:
                 # Make sure that the order is in state READY before moving on.
                 if e.code == "orderNotReady":
+                    # the Retry-After header is not accessible here
                     await asyncio.sleep(self.FINALIZE_DELAY)
                 else:
                     raise e

--- a/acmetk/server/server.py
+++ b/acmetk/server/server.py
@@ -68,7 +68,7 @@ async def handle_get(request: web.Request) -> web.Response:
 
 
 class AcmeResponse(web.Response):
-    def __init__(self, nonce, directory_url, *args, links=None, **kwargs):
+    def __init__(self, nonce: str, directory_url: str, *args, links: list[str] | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         if links is None:
             links = []
@@ -97,6 +97,11 @@ async def on_shutdown(app: web.Application):
 async def on_cleanup(app: web.Application):
     obj: AcmeServerBase = app[AcmeServerBase.ServerKey]
     await obj.on_cleanup(app)
+
+
+class ConfigRetryAfter(BaseSettings):
+    authz: int = 3
+    order: int = 7
 
 
 class AcmeServerBase(PrometheusMetricsMixin, AcmeEABMixin, AcmeManagementMixin, ServiceBase, abc.ABC):
@@ -220,6 +225,8 @@ class AcmeServerBase(PrometheusMetricsMixin, AcmeEABMixin, AcmeManagementMixin, 
         """
         prometheus metrics export at /metrics
         """
+
+        retryafter: ConfigRetryAfter = Field(default_factory=lambda: ConfigRetryAfter())
 
     @staticmethod
     def _extract_mixin_config(
@@ -974,6 +981,7 @@ class AcmeServerBase(PrometheusMetricsMixin, AcmeEABMixin, AcmeManagementMixin, 
 
         :return: The authorization object.
         """
+        headers = dict()
         async with self._session(request) as session:
             jws, account = await self._verify_request(request, session)
             authz_id = request.match_info["id"]
@@ -988,10 +996,15 @@ class AcmeServerBase(PrometheusMetricsMixin, AcmeEABMixin, AcmeManagementMixin, 
             except ValueError as e:
                 raise acme.messages.Error.with_code("malformed", detail=e.args[0])
 
+            if authorization.status == models.AuthorizationStatus.PENDING:
+                for challenge in authorization.challenges:
+                    if challenge.status == models.ChallengeStatus.PENDING:
+                        headers["Retry-After"] = str(self._c.retryafter.authz)
+
             serialized = authorization.serialize(request)
             await session.commit()
 
-        return self._response(request, serialized)
+        return self._response(request, serialized, headers=headers)
 
     @routes.post("/challenge/{id}", name="challenge")
     async def challenge(self, request: web.Request) -> web.Response:
@@ -1069,13 +1082,23 @@ class AcmeServerBase(PrometheusMetricsMixin, AcmeEABMixin, AcmeManagementMixin, 
             jws, account = await self._verify_request(request, session, post_as_get=True)
             order_id = request.match_info["id"]
 
-            order = await self._db.get_order(session, account.account_id, order_id)
+            order: models.order.Order = await self._db.get_order(session, account.account_id, order_id)
             if not order:
                 raise web.HTTPNotFound
 
             await order.validate()
+            headers = dict()
+            if order.status == models.OrderStatus.PROCESSING:
+                """
+                7.4.  Applying for Certificate Issuance
+                …
+                   o  "processing": The certificate is being issued.  Send a POST-as-GET
+                      request after the time given in the Retry-After header field of
+                      the response, if any.
+                """
+                headers["Retry-After"] = str(self._c.retryafter.order)
 
-            return self._response(request, order.serialize(request))
+            return self._response(request, order.serialize(request), headers=headers)
 
     @routes.post("/orders/{id}", name="orders")
     async def orders(self, request: web.Request) -> web.Response:

--- a/conf/proxy.config.sample.yml
+++ b/conf/proxy.config.sample.yml
@@ -21,6 +21,9 @@ service:
   allow_wildcard: true
   eab:
     required: false
+  retryafter:
+    authz: 3
+    order: 7
   client:
     directory: 'https://acme-v02.api.letsencrypt.org/directory' # Let's Encrypt directory
     private_key: '/etc/acme_server/proxy_client_account.key'

--- a/tests/retryafter_test.py
+++ b/tests/retryafter_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from .clients import acmetkClient
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_ourclient_retryafter(tmp_path_factory, service):
+    cipher, length = "RSA", 4096
+    name = "acmetk"
+
+    directory: str = str(service.directory)
+    tmpdir = tmp_path_factory.mktemp(name)
+    client = acmetkClient((cipher, length), service, directory, tmpdir)
+
+    cert_key = client._make_key(client.tmpdir / "cert_key.pem", ("RSA", 4096))
+    names = ["localhost"]
+    import acmetk.util
+
+    csr = acmetk.util.generate_csr(names[0], cert_key, client.tmpdir / "csr.pem", names)
+
+    await client.register()
+
+    assert isinstance(client.client._directory["renewalInfo"], str)
+
+    domains = client.domains_of_csr(csr)
+    identifiers = client.identifiers_from_names(domains)
+    ord_ = await client.client.order_create(identifiers)
+
+    for authorization_url in ord_.authorizations:
+        resp, authorization = await client.client._signed_request(None, authorization_url)
+        assert int(resp.headers["Retry-After"]) == 3
+
+    await client.client.authorizations_complete(ord_)
+
+    from acme import messages
+
+    cert_req = messages.CertificateRequest(csr=csr)
+
+    resp, order_obj = await client.client._signed_request(cert_req, ord_.finalize)
+
+    order_url = resp.headers["Location"]
+    resp, order = await client.client._signed_request(None, order_url)
+    assert int(resp.headers["Retry-After"]) == 7


### PR DESCRIPTION
after order-finalize the order is polled for status acme.sh tries 30 times and waits Retry-After|2 seconds after each attempt setting the header increases the total time before acme.sh will fail